### PR TITLE
Ensure config path uses server install directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,8 @@ This repository contains a simple Python based manager for the Arma 3 dedicated 
 
 ## Configuration
 
-Modify `config.yaml` to match your setup:
+Modify `config.yaml` to match your setup. `server_config_path` will default to
+`<server_path>/server.cfg` if not explicitly set:
 
 ```yaml
 server_path: /opt/arma3            # Where to install the server

--- a/arma3_manager.py
+++ b/arma3_manager.py
@@ -35,15 +35,18 @@ def download_mods(cfg):
 
 
 def apply_config(cfg):
-    config_file = cfg.get('server_config_path')
+    server_path = cfg.get('server_path', '/opt/arma3')
+    config_file = cfg.get('server_config_path', os.path.join(server_path, 'server.cfg'))
     config_content = cfg.get('server_config')
-    if config_file and config_content:
-        with open(config_file, 'w') as f:
-            f.write(config_content)
-        print(f"Wrote server config to {config_file}")
-        return True
-    print('No server_config_path or server_config provided in config')
-    return False
+    if not config_content:
+        print('No server_config provided in config')
+        return False
+
+    os.makedirs(os.path.dirname(config_file), exist_ok=True)
+    with open(config_file, 'w') as f:
+        f.write(config_content)
+    print(f"Wrote server config to {config_file}")
+    return True
 
 
 if __name__ == '__main__':

--- a/config.yaml
+++ b/config.yaml
@@ -1,5 +1,6 @@
 # Example configuration for arma3_manager.py
 server_path: /opt/arma3
+# server_config_path defaults to <server_path>/server.cfg if not set
 server_config_path: /opt/arma3/server.cfg
 server_config: |
   // Example server.cfg


### PR DESCRIPTION
## Summary
- default `server_config_path` to `<server_path>/server.cfg`
- clarify default config path in README and example config

## Testing
- `python3 -m py_compile arma3_manager.py`
- `pip install -r requirements.txt`

------
https://chatgpt.com/codex/tasks/task_e_687697d21918832597b387f96786952b