### PR TITLE
Add setup script to install SteamCMD and dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,14 @@ This repository contains a simple Python based manager for the Arma 3 dedicated 
 - Install Python dependencies with `pip install -r requirements.txt`
 - (Optional) `STEAM_USERNAME` and `STEAM_PASSWORD` environment variables for downloading mods from the Workshop
 
+## Setup
+
+Run the `setup.sh` script to install SteamCMD and the Python requirements. The script requires sudo privileges on Debian/Ubuntu based systems:
+
+```bash
+./setup.sh
+```
+
 ## Configuration
 
 Modify `config.yaml` to match your setup. `server_config_path` will default to

--- a/setup.sh
+++ b/setup.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+set -e
+
+# Ensure multiverse repository is enabled and i386 architecture is available
+sudo apt-get update
+sudo apt-get install -y software-properties-common
+sudo dpkg --add-architecture i386
+sudo add-apt-repository -y multiverse
+sudo apt-get update
+
+# Install required packages including steamcmd and Python
+sudo apt-get install -y python3 python3-pip steamcmd lib32gcc-s1
+
+# Install Python dependencies for the manager
+sudo pip3 install --upgrade -r requirements.txt
+
+echo "Installation complete"


### PR DESCRIPTION
## Summary
- add `setup.sh` that installs SteamCMD, Python, and requirements
- mention setup script in README

## Testing
- `python3 -m py_compile arma3_manager.py`
- `pip3 install --user -r requirements.txt`

------
https://chatgpt.com/codex/tasks/task_e_68769a3c5b6083259da49b932dba74ec