### PR TITLE
Improve setup.sh with venv and guidance

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -9,9 +9,31 @@ sudo add-apt-repository -y multiverse
 sudo apt-get update
 
 # Install required packages including steamcmd and Python
-sudo apt-get install -y python3 python3-pip steamcmd lib32gcc-s1
+sudo apt-get install -y python3 python3-full python3-venv python3-pip \
+    steamcmd lib32gcc-s1
 
-# Install Python dependencies for the manager
-sudo pip3 install --upgrade -r requirements.txt
+# Create an isolated Python virtual environment to avoid the
+# "externally-managed-environment" error when installing packages
+python3 -m venv .venv
+source .venv/bin/activate
+pip install --upgrade pip
+pip install -r requirements.txt
+deactivate
+
+cat <<'EOF'
+If pip refuses to install packages due to the "externally-managed-environment"
+policy on Debian-based systems, you can:
+
+1. Install packages via apt, e.g. sudo apt install python3-xyz
+2. Use a virtual environment:
+     python3 -m venv /path/to/venv
+     /path/to/venv/bin/pip install <package>
+3. Use pipx for command-line tools:
+     pipx install <package>
+
+You may override the restriction with
+    pip install --break-system-packages <package>
+but this is not recommended as it can conflict with system packages.
+EOF
 
 echo "Installation complete"


### PR DESCRIPTION
## Summary
- use python virtual environment instead of installing packages globally
- provide instructions for dealing with the "externally-managed-environment" error

## Testing
- `bash -n setup.sh`
- `python3 -m py_compile arma3_manager.py`
- `sudo apt-get update` *(fails: domain blocked)*

------
https://chatgpt.com/codex/tasks/task_e_68769c0ace2c8325b90fcb803d5d0e4c