### PR TITLE
Fix Arma 3 server install with steamcmd

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,10 @@ python3 arma3_manager.py apply-config      # write server.cfg as configured
 python3 arma3_manager.py all               # perform all actions above
 ```
 
+When calling `steamcmd` manually, always specify `+force_install_dir` *before*
+the `+login` argument. Otherwise SteamCMD will emit "Please use force_install_dir
+before logon!" and refuse to install the server.
+
 To download mods you must set the `STEAM_USERNAME` and `STEAM_PASSWORD` environment variables to a Steam account that owns Arma 3 and is subscribed to the desired mods.
 
 You can automate updates by running the script periodically with `cron` or a systemd timer.

--- a/arma3_manager.py
+++ b/arma3_manager.py
@@ -12,7 +12,13 @@ def run_command(command):
 
 def update_server(cfg):
     server_path = cfg.get('server_path', '/opt/arma3')
-    cmd = f"steamcmd +login anonymous +force_install_dir {server_path} +app_update 233780 validate +quit"
+    # force_install_dir must be specified before login or SteamCMD will refuse
+    # to install the app. See the SteamCMD error "Please use force_install_dir
+    # before logon!" if the order is incorrect.
+    cmd = (
+        f"steamcmd +force_install_dir {server_path} "
+        f"+login anonymous +app_update 233780 validate +quit"
+    )
     return run_command(cmd)
 
 


### PR DESCRIPTION
## Summary
- fix the order of arguments passed to SteamCMD
- document how to call SteamCMD correctly

## Testing
- `python3 -m py_compile arma3_manager.py`

------
https://chatgpt.com/codex/tasks/task_e_6876a8f9f18083258676e141b7213e80